### PR TITLE
Fix zero division in Expression._to_sympy

### DIFF
--- a/progressive_grammar_system.py
+++ b/progressive_grammar_system.py
@@ -67,10 +67,11 @@ class Expression:
                     result *= arg
                 return result
             elif self.operator == '/':
-                try:
-                    return args[0] / args[1]
-                except ZeroDivisionError:
+                # Check if the divisor is numerically zero before creating the expression
+                if hasattr(args[1], 'is_zero') and args[1].is_zero:
                     return sp.nan
+                else:
+                    return args[0] / args[1]
             elif self.operator == '**':
                 return args[0] ** args[1]
         elif self.operator == 'diff':


### PR DESCRIPTION
## Summary
- handle symbolic division by zero in `Expression._to_sympy`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6850694b5ecc8332b835361fbe4b1f9c