### PR TITLE
Refactor: Replace print with logging and add structured exceptions.

### DIFF
--- a/custom_exceptions.py
+++ b/custom_exceptions.py
@@ -1,0 +1,17 @@
+# custom_exceptions.py
+
+class MissingDependencyError(ImportError):
+    """Custom exception for missing optional or core dependencies."""
+    pass
+
+class PluginNotFoundError(LookupError):
+    """Custom exception for when a specified plugin, algorithm, or environment cannot be found."""
+    pass
+
+class InvalidConfigError(ValueError):
+    """Custom exception for errors in experiment configurations."""
+    pass
+
+class DataGenerationError(RuntimeError):
+    """Custom exception for failures during data generation in an environment."""
+    pass


### PR DESCRIPTION
- I introduced custom exception classes: MissingDependencyError, PluginNotFoundError, InvalidConfigError, DataGenerationError in `custom_exceptions.py`.
- I refactored `experiment_runner.py` to raise these custom exceptions for issues related to plugin loading, configuration errors, and data generation failures.
- I replaced `print()` calls with `logger` calls in `experiment_runner.py`, including its `if __name__ == '__main__'` block, and configured logging for the main block.
- I replaced `print()` calls with `logger.info()` for DataFrame output in `ExperimentRunner.analyze_results()`.

Note: My attempts to replace `print()` calls with `logging` in `run_phase1_experiments.py` were unsuccessful due to persistent errors. I reviewed the exception handling in this file and considered it improved by the more descriptive exceptions it will now receive from the runner.