### PR TITLE
Fix: Add assertion for observation dimension in HypothesisNet

### DIFF
--- a/hypothesis_policy_network.py
+++ b/hypothesis_policy_network.py
@@ -325,6 +325,11 @@ class HypothesisNet(nn.Module):
 
         batch_size, obs_dim = observation.shape
         # Dynamically infer how many nodes are present
+        if obs_dim % self.node_feature_dim != 0:
+            raise ValueError(
+                f"Observation dimension ({obs_dim}) is not a multiple of "
+                f"node_feature_dim ({self.node_feature_dim})."
+            )
         num_nodes = obs_dim // self.node_feature_dim
         if self.debug:
             print(f"[DEBUG] computed num_nodes={num_nodes}, node_feature_dim={self.node_feature_dim}, obs_size={obs_dim}")


### PR DESCRIPTION
Adds an assertion to `HypothesisNet.forward` to ensure that the observation dimension is a multiple of `node_feature_dim`. This prevents potential runtime errors if the observation padding logic changes.

A ValueError is raised with a descriptive message if the check fails.

Note: I had planned to add a unit test for this change, but I encountered an issue with a corrupted torch installation in the testing environment which prevented the test from running.