### PR TITLE
Fix: Improve reward function stability in SymbolicDiscoveryEnv

### DIFF
--- a/progressive_grammar_system.py
+++ b/progressive_grammar_system.py
@@ -43,7 +43,9 @@ class Expression:
 
     def _to_sympy(self) -> sp.Expr:
         if self.operator == 'var':
-            return sp.Symbol(self.operands[0])
+            if isinstance(self.operands[0], sp.Symbol):
+                return self.operands[0]  # Already a symbol
+            return sp.Symbol(self.operands[0]) # Create from string name
         elif self.operator == 'const':
             return sp.Float(self.operands[0])
         elif self.operator in ['+', '-', '*', '/', '**']:

--- a/symbolic_discovery_env.py
+++ b/symbolic_discovery_env.py
@@ -191,7 +191,8 @@ class SymbolicDiscoveryEnv(gym.Env):
         default_reward_config = {
             'completion_bonus':    0.1,
             'validity_bonus':      0.05,
-            'mse_weight':         -1.0,
+            'mse_weight':          1.0,
+            'mse_scale_factor':    1.0,
             'complexity_penalty': -0.01,
             'depth_penalty':      -0.001,
             'timeout_penalty':    -1.0,
@@ -291,7 +292,7 @@ class SymbolicDiscoveryEnv(gym.Env):
         norm = mse / (np.var(tars) + 1e-10)
         reward = (
             self.reward_config.get('completion_bonus', 0.1) +
-            self.reward_config.get('mse_weight', -1.0) * np.log(norm + 1e-10) +
+            self.reward_config.get('mse_weight', 1.0) * np.exp(-self.reward_config.get('mse_scale_factor', 1.0) * norm) +
             self.reward_config.get('complexity_penalty', -0.01) * expr.complexity +
             self.reward_config.get('depth_penalty', -0.001) * self.max_depth
         )


### PR DESCRIPTION
Replaces the log-based MSE penalty in the reward function with a bounded, exponential decay function. This change addresses potential instability caused by large negative rewards when MSE is high.

Key changes:
- Modified `SymbolicDiscoveryEnv._evaluate_expression` to use `np.exp(-mse_scale_factor * norm_mse)` for the MSE component of the reward.
- Added `mse_scale_factor` to `default_reward_config` (default 1.0).
- Changed `mse_weight` in `default_reward_config` to be positive (default 1.0).
- Added `test_reward_function_mse_component` to `tests/test_symbolic_discovery_env.py` to verify the new reward logic, including checks for low/high MSE and the effect of `mse_scale_factor`.
- Updated existing test `test_explicit_target_evaluation` to align with the new reward calculation.
- Minor fix in `Expression._to_sympy` in `progressive_grammar_system.py` to handle operands that are already Sympy symbols.