### PR TITLE
I've updated the `ProgressiveGrammar` and `TaskEnvironmentBuilder`.

### DIFF
--- a/maml-training-framework.py
+++ b/maml-training-framework.py
@@ -269,7 +269,8 @@ class TaskEnvironmentBuilder:
     
     def _create_task_grammar(self, task: PhysicsTask) -> ProgressiveGrammar:
         """Create grammar with operators appropriate for task"""
-        grammar = ProgressiveGrammar()
+        # Initialize an EMPTY grammar
+        grammar = ProgressiveGrammar(load_defaults=False)
         
         # Base operators for all physics
         base_ops = ['+', '-', '*', '/']
@@ -286,10 +287,11 @@ class TaskEnvironmentBuilder:
             grammar.add_operators(['log', 'exp', '**'])
             
         elif task.domain == "electromagnetism":
-            grammar.add_operators(['**2', '**3', '1/'])
+            # '**2' handles r**2, '1/' is mapped to 'inv' for 1/r
+            grammar.add_operators(['**2', '1/']) # Corrected: removed '**3'
         
-        # Add special operators based on true law
-        if "**" in task.true_law and "**2" not in grammar.operators:
+        # Add special operators based on true law (optional, for guidance)
+        if "**" in task.true_law: # Corrected: removed "and '**2' not in grammar.operators"
             grammar.add_operators(['**'])
         
         return grammar


### PR DESCRIPTION
Here's what I changed in the `ProgressiveGrammar` class within `progressive_grammar_system.py`:
- I added a `load_defaults` parameter to the `__init__` method. This allows for initializing an empty grammar if needed.
- I introduced an `add_operators` method, which lets you dynamically add operators to the grammar.

And here are the updates to the `_create_task_grammar` method in `maml-training-framework.py`:
- I now initialize `ProgressiveGrammar` with `load_defaults=False`.
- I'm using the new `add_operators` method for adding operators.
- I've corrected the list of operators for the 'electromagnetism' domain.
- I've simplified the logic for adding the '**' operator, making it dependent on `task.true_law`.