### PR TITLE
Fix: Correctly unpack env.reset() return value

### DIFF
--- a/maml-training-framework.py
+++ b/maml-training-framework.py
@@ -460,7 +460,7 @@ class MAMLTrainer:
         trajectories = []
         
         for episode in range(n_episodes):
-            obs = env.reset()
+            obs, _ = env.reset()
             trajectory = {
                 'observations': [],
                 'actions': [],


### PR DESCRIPTION
The env.reset() method returns a tuple (observation, info). This change modifies the assignment to correctly unpack the tuple, assigning only the observation to the obs variable and discarding the info dictionary, which is not used in this part of the loop.