### PR TITLE
Fix: Ensure consistent action space in MAML framework

### DIFF
--- a/maml-training-framework.py
+++ b/maml-training-framework.py
@@ -269,12 +269,11 @@ class TaskEnvironmentBuilder:
     
     def _create_task_grammar(self, task: PhysicsTask) -> ProgressiveGrammar:
         """Create grammar with operators appropriate for task"""
+        # Using load_defaults=True ensures a standardized grammar
+        # with all possible operators, guaranteeing a consistent
+        # action space across all environments.
         # Initialize an EMPTY grammar
-        grammar = ProgressiveGrammar(load_defaults=False)
-        
-        # Base operators for all physics
-        base_ops = ['+', '-', '*', '/']
-        grammar.add_operators(base_ops)
+        grammar = ProgressiveGrammar(load_defaults=True)
         
         # Domain-specific operators
         if task.domain == "mechanics":


### PR DESCRIPTION
Standardized grammar creation in TaskEnvironmentBuilder by initializing ProgressiveGrammar with load_defaults=True. This ensures that all environments share the same action space, preventing potential IndexErrors in the MetaLearningPolicy due to mismatched action dimensions.

Removed redundant manual addition of base operators as they are now loaded by default. Added a comment to clarify the purpose of load_defaults=True.