### PR TITLE
Integrate new fidelity calculation methods

### DIFF
--- a/janus/ai_interpretability/rewards/fidelity_reward.py
+++ b/janus/ai_interpretability/rewards/fidelity_reward.py
@@ -1,5 +1,7 @@
 import numpy as np
-from typing import Any, Callable
+from typing import Any, Callable, Dict, Union, Optional
+import torch
+import sympy as sp
 
 # Assuming Expression and AIBehaviorData are accessible.
 # from ...core.progressive_grammar_system import Expression
@@ -27,6 +29,70 @@ class FidelityRewardCalculator:
         """
         self.behavior_data = behavior_data
         self.evaluate_expression_func = evaluate_expression_func
+
+    def _get_model_output(self, features: np.ndarray) -> np.ndarray:
+        """
+        Get model outputs for given features.
+        Handles different model types and ensures consistent output format.
+        """
+        self.ai_model.eval()
+        with torch.no_grad():
+            inputs = torch.tensor(features, dtype=torch.float32)
+            if inputs.dim() == 1:
+                inputs = inputs.unsqueeze(0)
+
+            output_tensor = self.ai_model(inputs)
+
+            if hasattr(output_tensor, 'logits'):
+                output_tensor = output_tensor.logits
+            elif isinstance(output_tensor, tuple):
+                output_tensor = output_tensor[0]
+
+            output_array = output_tensor.cpu().numpy()
+
+            if output_array.ndim > 2:
+                output_array = output_array.reshape(output_array.shape[0], -1)
+            return output_array
+
+    def _evaluate_expression_on_data(self, expression: Any, data: Union[np.ndarray, Dict[str, np.ndarray]]) -> Optional[np.ndarray]:
+        """
+        Evaluate a symbolic expression on input data.
+        """
+        if expression is None or not hasattr(expression, 'symbolic'):
+            return None
+        try:
+            var_mapping = {}
+            if isinstance(data, dict):
+                for var in self.variables:
+                    if var.name in data:
+                        var_mapping[var.symbolic] = data[var.name]
+            else:
+                for var in self.variables:
+                    if var.index < data.shape[1]:
+                        var_mapping[var.symbolic] = data[:, var.index]
+
+            # Use lambdify for fast evaluation
+            func = sp.lambdify(
+                list(var_mapping.keys()),
+                expression.symbolic,
+                modules=['numpy', {'Attention': self._compute_attention_value}]
+            )
+            result = func(*var_mapping.values())
+            return np.array(result).flatten()
+        except Exception as e:
+            print(f"Expression evaluation failed: {e}")
+            return None
+
+    def _compute_attention_value(self, query, key, value):
+        """Computes simplified scalar attention."""
+        score = query * key
+        attention_weight = np.exp(score) / (np.exp(score) + 1)
+        return attention_weight * value
+
+    def _compute_embedding_value(self, index, embedding_ref):
+        """Computes placeholder embedding lookup."""
+        index = int(index)
+        return float(hash(f"embed_{index}_{embedding_ref}") % 100) / 100.0
 
     def calculate_fidelity_score(self, expression: Expression) -> float:
         """

--- a/janus/ai_interpretability/utils/math_utils.py
+++ b/janus/ai_interpretability/utils/math_utils.py
@@ -93,6 +93,8 @@ def validate_inputs(func):
 
 import importlib
 from typing import Optional, Any
+import torch
+import numpy as np
 
 def safe_import(module_name: str, pip_install_name: Optional[str] = None, alias: Optional[str] = None) -> Optional[Any]:
     """
@@ -334,3 +336,27 @@ if __name__ == '__main__':
 
 
     print("\nAll local tests for math_utils.py complete (pending execution).")
+
+
+def self_attention_primitive(query: torch.Tensor, key: torch.Tensor, value: torch.Tensor, mask: Optional[torch.Tensor] = None) -> torch.Tensor:
+    """
+    Implements self-attention mechanism for transformer models.
+    """
+    hidden_dim = query.shape[-1]
+    scores = torch.matmul(query, key.transpose(-2, -1)) / np.sqrt(hidden_dim)
+    if mask is not None:
+        scores = scores.masked_fill(mask == 0, -1e9)
+    attention_weights = torch.softmax(scores, dim=-1)
+    output = torch.matmul(attention_weights, value)
+    return output
+
+def position_encoding_primitive(seq_len: int, hidden_dim: int, max_len: int = 5000) -> torch.Tensor:
+    """
+    Generate sinusoidal position encodings.
+    """
+    position = torch.arange(seq_len).unsqueeze(1).float()
+    div_term = torch.exp(torch.arange(0, hidden_dim, 2).float() * -(np.log(10000.0) / hidden_dim))
+    pos_encoding = torch.zeros(seq_len, hidden_dim)
+    pos_encoding[:, 0::2] = torch.sin(position * div_term)
+    pos_encoding[:, 1::2] = torch.cos(position * div_term)
+    return pos_encoding


### PR DESCRIPTION
Integrates new methods into the FidelityRewardCalculator class for more robust fidelity calculation:
- _get_model_output: Handles different model types and ensures consistent output format.
- _evaluate_expression_on_data: Evaluates symbolic expressions on input data.
- _compute_attention_value: Computes simplified scalar attention.
- _compute_embedding_value: Computes placeholder embedding lookup.

Adds transformer-specific primitives to math_utils.py:
- self_attention_primitive: Implements self-attention mechanism.
- position_encoding_primitive: Generates sinusoidal position encodings.